### PR TITLE
fix: Add config to constructor for google logger driver

### DIFF
--- a/src/services/logging/Service.ts
+++ b/src/services/logging/Service.ts
@@ -1,15 +1,27 @@
-import { Service, VisionElixirConfig } from '../app/types'
+import { KeyValue, Service, VisionElixirConfig } from '../app/types'
 import { VisionElixirLogger } from './lib/VisionElixirLogger'
 import { Container } from '../container/types'
-import { LoggingDriver, SERVICE_LOGGER } from './types'
+import {
+  GoogleCloudLoggingConfig,
+  LoggingDriver,
+  SERVICE_LOGGER,
+} from './types'
 import { SERVICE_CONFIG } from '../config/types'
 
 export default class LoggerService implements Service {
   public applicationInit(container: Container): void {
-    const logger = new VisionElixirLogger(
-      container.resolve<VisionElixirConfig>(SERVICE_CONFIG).logging?.type ||
-        LoggingDriver.CONSOLE,
-    )
+    const loggerConfig = container.resolve<VisionElixirConfig>(SERVICE_CONFIG)
+    const loggingDriver: LoggingDriver =
+      loggerConfig.logging?.type || LoggingDriver.CONSOLE
+
+    let config: KeyValue = {}
+
+    switch (loggingDriver) {
+      case LoggingDriver.GCLOUD:
+        config = loggerConfig.logging?.googleCloud as GoogleCloudLoggingConfig
+        break
+    }
+    const logger = new VisionElixirLogger(loggingDriver, config)
 
     container.singleton(SERVICE_LOGGER, logger)
   }


### PR DESCRIPTION
The googleCloud config from the project app config file was not being passed into the constructor for the logger driver.

So I updated the logger service to pass that through to the constructor