### PR TITLE
fix: set status onto ctx if set in error options

### DIFF
--- a/src/services/error/middleware/ErrorMiddleware.ts
+++ b/src/services/error/middleware/ErrorMiddleware.ts
@@ -30,6 +30,10 @@ export class ErrorMiddleware {
 
         ctx.error = error
 
+        if (!ctx.status && error.options.status) {
+          ctx.status = error.options.status
+        }
+
         this.log(error, ctx)
       }
 


### PR DESCRIPTION
The new custom errors [Custom Error](https://github.com/green-brain/helpers_library/blob/aea2511a7a4d8e70ff88f405c762334744c3a9fc/src/core/errors/DeprecatedError.ts#L13) you have made it so you set the status in the custom error.

This status doesn't seem to be carried over to the ctx when the error middleware is run.
This means that the event is never fired [Error Middleware](https://github.com/visionelixir/framework/blob/060095f3323ac75e98c7d29b0778471535123a80/src/services/error/middleware/ErrorMiddleware.ts#L51) so we can't catch it.

This is happening on jobs, not sure if it is happening on apps.

Here I am just checking if there is not status on the ctx, but the status on the options to set it against the ctx.
This then allows the event to be fired